### PR TITLE
Implemented permission check

### DIFF
--- a/Sample/OpenALPRSample/app/src/main/java/com/sandro/openalprsample/MainActivity.java
+++ b/Sample/OpenALPRSample/app/src/main/java/com/sandro/openalprsample/MainActivity.java
@@ -1,20 +1,25 @@
 package com.sandro.openalprsample;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -39,6 +44,8 @@ public class MainActivity extends AppCompatActivity {
     private File destination;
     private TextView resultTextView;
     private ImageView imageView;
+
+    final int STORAGE=1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -74,6 +81,7 @@ public class MainActivity extends AppCompatActivity {
                 final ProgressDialog progress = ProgressDialog.show(this, "Loading", "Parsing result...", true);
 
                 final String openAlprConfFile = ANDROID_DATA_DIR + File.separatorChar + "runtime_data" + File.separatorChar + "openalpr.conf";
+                checkPermission();
                 FileInputStream in = new FileInputStream(destination);
                 BitmapFactory.Options options = new BitmapFactory.Options();
                 options.inSampleSize = 10;
@@ -115,6 +123,44 @@ public class MainActivity extends AppCompatActivity {
                 e.printStackTrace();
             }
 
+        }
+    }
+
+    private void checkPermission() {
+        int permissionCheck = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (permissionCheck != PackageManager.PERMISSION_GRANTED){
+            // Should we show an explanation?
+            if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                // Show an explanation to the user *asynchronously* -- don't block
+                // this thread waiting for the user's response! After the user
+                // sees the explanation, try again to request the permission.
+                Toast.makeText(this, "We require access to storage to manage the picture.", Toast.LENGTH_LONG).show();
+            } else {
+                // No explanation needed, we can request the permission.
+                ActivityCompat.requestPermissions(this,
+                        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                        STORAGE);
+                // WRITE_EXTERNAL_STORAGE is an app-defined int constant. The callback method gets the result of the request.
+            }
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+        switch (requestCode) {
+            case STORAGE:{
+                // If request is cancelled, the result arrays are empty.
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    // permission was granted, yay!
+                } else {
+                    // permission denied, boo! Disable the
+                    // functionality that depends on this permission.
+                    Toast.makeText(this,"Storage permision is needed to analye the picture.", Toast.LENGTH_LONG).show();
+                }
+            }
+            // other 'case' lines to check for other
+            // permissions this app might request
         }
     }
 


### PR DESCRIPTION
Introduced code to check for the write storage permission to properly support Android 6.0 devices. This should resolve the issue where the user is stuck on **Parsing Result**. This does not fix the issue when compiling from source resolves in a crash searching for a missing binary referencing in ticket #1 
