### PR TITLE
Created a folder on /sdcard/ for all images captured

### DIFF
--- a/Sample/OpenALPRSample/app/src/main/java/com/sandro/openalprsample/MainActivity.java
+++ b/Sample/OpenALPRSample/app/src/main/java/com/sandro/openalprsample/MainActivity.java
@@ -163,8 +163,15 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void takePicture() {
+        // Use a folder to store all results
+        File folder = new File(Environment.getExternalStorageDirectory() + "/OpenALPR/");
+        if (!folder.exists()) {
+            folder.mkdir();
+        }
+
+        // Generate the path for the next photo
         String name = dateToString(new Date(), "yyyy-MM-dd-hh-mm-ss");
-        destination = new File(Environment.getExternalStorageDirectory(), name + ".jpg");
+        destination = new File(folder, name + ".jpg");
 
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(destination));


### PR DESCRIPTION
Past implementation dumped images on root of /sdcard/. This resulted in a crowded sdcard.

The new implementation creates a folder named OpenALPR which will now store all the images.
