### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/org/openalpr/OpenALPR.java
+++ b/app/src/main/java/org/openalpr/OpenALPR.java
@@ -64,6 +64,8 @@ public interface OpenALPR {
      */
     class Factory {
 
+        private Factory() {}
+
         static OpenALPR instance;
 
         /**

--- a/app/src/main/java/org/openalpr/util/Utils.java
+++ b/app/src/main/java/org/openalpr/util/Utils.java
@@ -13,6 +13,8 @@ import java.io.OutputStream;
  */
 public class Utils {
 
+    private Utils() {}
+
     /**
      * Copies the assets folder.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
