### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/Sample/OpenALPRSample/app/src/main/java/com/sandro/openalprsample/MainActivity.java
+++ b/Sample/OpenALPRSample/app/src/main/java/com/sandro/openalprsample/MainActivity.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class MainActivity extends AppCompatActivity {
 
     private static final int REQUEST_IMAGE = 100;
-    final int STORAGE=1;
+    private static final int STORAGE=1;
     private String ANDROID_DATA_DIR;
     private static File destination;
     private TextView resultTextView;
@@ -134,7 +134,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         switch (requestCode) {
             case STORAGE:{
                 Map<String, Integer> perms = new HashMap<>();
@@ -153,6 +153,8 @@ public class MainActivity extends AppCompatActivity {
                     Toast.makeText(this, "Storage permission is needed to analyse the picture.", Toast.LENGTH_LONG).show();
                 }
             }
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1170 - Public constants should be declared "static final" rather than merely "final". 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1170
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

Faisal Hameed
