### PR TITLE
avoid class minification and obfuscation

### DIFF
--- a/Sample/OpenALPRSample/app/proguard-rules.pro
+++ b/Sample/OpenALPRSample/app/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keep class org.openalpr.model.** { *; }


### PR DESCRIPTION
https://stackoverflow.com/questions/30001674/gson-deserialize-null-pointer-in-released-apk
in release mode proguard change props names and then `final Results results = new Gson().fromJson(result, Results.class);` returns null value.
Solved problem for release mode scan -- issue was due gson.fromJson with minified/obfuscated class model